### PR TITLE
Make README start command work

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Now everything should be ready. Compile and run with:
 
 ```
 cargo build --release; \
-	and time ./target/release/rust-bitcoin-indexer \
+	time ./target/release/bitcoin-indexer \
 	--rpc-url http://localhost:8332 \
 	--rpc-user user --rpc-pass password
 ```

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ about inserting around billion records into 3 tables each.
 Now everything should be ready. Compile and run with:
 
 ```
-cargo build --release; \
+cargo build +nightly --release; \
 	time ./target/release/bitcoin-indexer \
 	--rpc-url http://localhost:8332 \
 	--rpc-user user --rpc-pass password

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(uniform_paths)]
+
 pub mod db;
 pub mod fetcher;
 pub mod opts;


### PR DESCRIPTION
When trying to get the rust-bitcoin-indexer running I ran into some issues with getting it to build. These 2 changes allow the indexer to build.

note I am still getting a 

```
    Finished release [optimized] target(s) in 0.19s
Error: path not found
./target/release/bitcoin-indexer --rpc-url http://localhost:8332 --rpc-user    0.00s user 0.00s system 72% cpu 0.004 total
```

error when it successfully runs, so that is an error for another day!

